### PR TITLE
Paypal standard improvements

### DIFF
--- a/ext/modules/payment/paypal/standard_ipn.php
+++ b/ext/modules/payment/paypal/standard_ipn.php
@@ -98,6 +98,7 @@ try {
         }
 
         $_POST['comments'] = $order->info['comments'] = $check['customer_comments'];
+        $order =& $GLOBALS['order']; // needed for insert history segment
         $hooks->register_pipeline('after');
         include 'includes/system/segments/checkout/insert_history.php';
 

--- a/includes/modules/payment/paypal_standard.php
+++ b/includes/modules/payment/paypal_standard.php
@@ -538,7 +538,7 @@ EOSQL
     }
 
     $notify_url = $GLOBALS['Linker']->build('ext/modules/payment/paypal/standard_ipn.php', [], false);
-    if (isset($ipn_language)) {
+    if (! is_null($ipn_language)) {
       $notify_url->set_parameter('language', $ipn_language);
     }
     $amount = ($GLOBALS['order']->info['total'] - $GLOBALS['order']->info['shipping_cost'] - $total_tax);
@@ -557,7 +557,7 @@ EOSQL
       'invoice' => $this->base_constant('INVOICE_PREFIX') . $order_id,
       'custom' => $_SESSION['customer_id'],
       'no_note' => '1',
-      'notify_url' => $GLOBALS['Linker']->build('ext/modules/payment/paypal/standard_ipn.php'),
+      'notify_url' => $notify_url,
       'rm' => '2',
       'return' => $GLOBALS['Linker']->build(static::RETURN_URL),
       'cancel_return' => $GLOBALS['Linker']->build('checkout_payment.php'),


### PR DESCRIPTION
Paypal Standard improvements in light of artfulweb experience:

1. Only make ajax call to save comment when there is a comment to save
2. Include http return code in saving comment failed error message
3. (Found in testing her fix) Ensure that orders completed by IPN send email in checkout language.


