### PR TITLE
Password forgotten notification

### DIFF
--- a/includes/languages/english/modules/notifications/n_password_forgotten.php
+++ b/includes/languages/english/modules/notifications/n_password_forgotten.php
@@ -1,0 +1,17 @@
+<?php
+/*
+  $Id$
+
+  CE Phoenix, E-Commerce made Easy
+  https://phoenixcart.org
+
+  Copyright (c) 2026 Phoenix Cart
+
+  Released under the GNU General Public License
+*/
+
+const MODULE_NOTIFICATIONS_PASSWORD_FORGOTTEN_TITLE = 'Password Forgotten Notification';
+const MODULE_NOTIFICATIONS_PASSWORD_FORGOTTEN_DESCRIPTION = 'Sends an email with the password reset link.';
+
+const MODULE_NOTIFICATIONS_PASSWORD_FORGOTTEN_TEXT_SUBJECT = STORE_NAME . ' - Password Reset';
+const MODULE_NOTIFICATIONS_PASSWORD_FORGOTTEN_TEXT_BODY = 'We received a request to reset your password for your account at ' . STORE_NAME . '.' . "\n\n" . 'Click the link below to choose a new password:' . "\n\n%s\n\n" . 'This link expires in 24 hours.' . "\n\n" . 'Need help? Contact us at: ' . STORE_OWNER_EMAIL_ADDRESS . '.' . "\n\n";

--- a/includes/languages/english/password_forgotten.php
+++ b/includes/languages/english/password_forgotten.php
@@ -21,9 +21,6 @@ const TEXT_PASSWORD_RESET_INITIATED = 'Check your email for a password reset lin
 
 const TEXT_NO_EMAIL_ADDRESS_FOUND = 'If this email is in our records, we\'ve sent you a reset link. Please check your inbox.';
 
-const EMAIL_PASSWORD_RESET_SUBJECT = STORE_NAME . ' - Password Reset';
-const EMAIL_PASSWORD_RESET_BODY = 'We received a request to reset your password for your account at ' . STORE_NAME . '.' . "\n\n" . 'Click the link below to choose a new password:' . "\n\n%s\n\n" . 'This link expires in 24 hours.' . "\n\n" . 'Need help? Contact us at: ' . STORE_OWNER_EMAIL_ADDRESS . '.' . "\n\n";
-
 const ERROR_ACTION_RECORDER = 'Error: A password reset link has already been sent. Please try again in %s minutes.';
 
 const IMAGE_BUTTON_RESET_PASSWORD = 'Reset my Password';

--- a/includes/modules/notifications/n_password_forgotten.php
+++ b/includes/modules/notifications/n_password_forgotten.php
@@ -1,0 +1,44 @@
+<?php
+/*
+  $Id$
+
+  CE Phoenix, E-Commerce made Easy
+  https://phoenixcart.org
+
+  Copyright (c) 2026 Phoenix Cart
+
+  Released under the GNU General Public License
+*/
+
+  class n_password_forgotten extends abstract_module {
+
+    const CONFIG_KEY_BASE = 'MODULE_NOTIFICATIONS_PASSWORD_FORGOTTEN_';
+
+    const TRIGGERS = [ 'password_forgotten' ];
+
+    public function notify($data) {
+      ob_start();
+      include Guarantor::ensure_global('Template')->map(__FILE__);
+      
+      return Notifications::mail(
+          $data['name'], 
+          $data['email_address'], 
+          MODULE_NOTIFICATIONS_PASSWORD_FORGOTTEN_TEXT_SUBJECT, 
+          ob_get_clean(), 
+          STORE_OWNER, 
+          STORE_OWNER_EMAIL_ADDRESS
+      );
+    }
+
+    protected function get_parameters() {
+      return [
+        static::CONFIG_KEY_BASE . 'STATUS' => [
+          'title' => 'Enable Password Forgotten Notification module',
+          'value' => 'True',
+          'desc' => 'Do you want to add the module to your shop?',
+          'set_func' => "Config::select_one(['True', 'False'], ",
+        ],
+      ];
+    }
+
+  }

--- a/includes/modules/notifications/templates/tpl_n_password_forgotten.php
+++ b/includes/modules/notifications/templates/tpl_n_password_forgotten.php
@@ -1,0 +1,14 @@
+<?php
+/*
+  $Id$
+
+  CE Phoenix, E-Commerce made Easy
+  https://phoenixcart.org
+
+  Copyright (c) 2026 Phoenix Cart
+
+  Released under the GNU General Public License
+*/
+
+  printf(MODULE_NOTIFICATIONS_PASSWORD_FORGOTTEN_TEXT_BODY, $data['reset_url']);
+?>

--- a/password_forgotten.php
+++ b/password_forgotten.php
@@ -40,13 +40,11 @@
           $reset_key_url = str_replace('&amp;', '&', $reset_key_url);
         }
 
-        Notifications::mail(
-          $customer_data->get('name', $check_customer),
-          $email_address,
-          EMAIL_PASSWORD_RESET_SUBJECT,
-          sprintf(EMAIL_PASSWORD_RESET_BODY, $reset_key_url),
-          STORE_OWNER,
-          STORE_OWNER_EMAIL_ADDRESS);
+        Notifications::notify('password_forgotten', [
+            'name'          => $customer_data->get('name', $check_customer),
+            'email_address' => $email_address,
+            'reset_url'     => $reset_key_url
+        ]);
 
         $password_reset_initiated = true;
       } else {


### PR DESCRIPTION
Explain the details for making this change. What existing problem does it solve?

https://github.com/CE-PhoenixCart/PhoenixCart/discussions/111

Currently, the password_forgotten.php script uses a hardcoded email generation routine directly in the root file. This makes it impossible for shop owners to customize, heavily style, or convert the password reset email to HTML without modifying core files.

This proposal updates password_forgotten.php to route the reset email through the existing Notifications::notify() system. This brings the password reset architecture completely in line with the modern "Create Account" and "Order Update" modular notification systems.

Test plan (required)

Baseline Test: On a stock 1.1.0.7 install, trigger a password reset. Observe the standard plain-text email arrives via the hardcoded root file routine.

Apply Changes:

    Replace the $db->query email block in password_forgotten.php with Notifications::notify('password_forgotten', [...]);

    Upload the proposed stock n_password_forgotten controller, template, and language file.

Core Verification: Trigger another password reset. Observe that the exact same plain-text email arrives, proving the module perfectly replicates core functionality.

Override Verification: Install a custom/3rd-party HTML notification module mapped to the password_forgotten trigger. Run the reset form again and observe that the custom HTML email is delivered without any further core modifications.